### PR TITLE
fix: prevent connection timeout in `PreProcessingQA.make_insert`

### DIFF
--- a/element_moseq/moseq_train.py
+++ b/element_moseq/moseq_train.py
@@ -802,6 +802,10 @@ class PreProcessingQA(dj.Computed):
         """
         Insert QA data into the PreProcessingQA table and part tables.
         """
+        import datajoint as dj
+
+        dj.conn().connect()
+
         # Insert in the main table
         self.insert1(
             {
@@ -812,17 +816,14 @@ class PreProcessingQA(dj.Computed):
         )
 
         # Insert QA materials (plots and videos)
-        if qa_data:
-            self.VideoQA.insert(
-                [
-                    {
-                        **key,
-                        "video_id": data["video_id"],
-                        "outlier_plot": data["outlier_plot_path"],
-                        "overlay_video": data["overlay_video_path"],
-                    }
-                    for data in qa_data
-                ]
+        for data in qa_data:
+            self.VideoQA.insert1(
+                {
+                    **key,
+                    "video_id": data["video_id"],
+                    "outlier_plot": data["outlier_plot_path"],
+                    "overlay_video": data["overlay_video_path"],
+                },
             )
 
 


### PR DESCRIPTION
Add `dj.conn().connect()` to ensure fresh DB connection after long computation.

The `make_compute()` for `PreProcessingQA` can take several minutes generating QA videos, causing the DB connection to timeout before `make_insert()` runs. This results in "Connection was lost during a transaction" errors.

Also changed batch `insert` to `insert1` loop for `VideoQA` entries for consistency with other `make_insert` implementations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses connection loss during long QA generation and standardizes insert behavior.
> 
> - Add `dj.conn().connect()` in `PreProcessingQA.make_insert` to refresh the DataJoint connection before inserts
> - Replace batch `VideoQA.insert([...])` with a per-item `insert1` loop over `qa_data`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f82f5980baf5b0afbe55c8c129b24dea85c9b7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->